### PR TITLE
Set popupBox height to %90, so it can be scrollable

### DIFF
--- a/bypass_script.user.js
+++ b/bypass_script.user.js
@@ -222,7 +222,7 @@
         popupBox.style.color = "#d7dde8";
         popupBox.style.borderRadius = "10px";
         popupBox.style.width = "30%";
-        popupBox.style.height = "auto";
+        popupBox.style.height = "90%";
         popupBox.style.maxWidth = "600px";
 
         button.addEventListener('click', handleButtonClick);


### PR DESCRIPTION
If a gallery contains many files, the popupBox will be much taller because of height: auto. This will block access to the buttons below and make some links invisible.

That's why I wanted to limit the height to 90%.

By the way, if that's of interest, I'm using Zen Browser (based on Mozilla Firefox) as my browser; I haven't tried it with other browsers.